### PR TITLE
Use six to support Python 2 and Python 3.

### DIFF
--- a/poxx.py
+++ b/poxx.py
@@ -20,7 +20,7 @@ import optparse
 import os.path
 import re
 import polib    # from http://bitbucket.org/izi/polib
-import HTMLParser
+from six.moves import html_parser as HTMLParser
 
 VERSION_STR = '1.1.1'
 
@@ -181,4 +181,4 @@ if __name__ == "__main__":
         else:
             report_msg = munge_one_file(fname, options.blank, canon_name=options.canonical_po_file)
 
-    print report_msg
+    print(report_msg)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 polib
+six

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ VERSION_STR = '.'.join(str(v) for v in (1,1,0))
 
 install_requires = [
     'polib',
+    'six',
 ]
 
 test_requires = ['pytest']


### PR DESCRIPTION
I would be willing to support this library on pypi, unless there is a more compelling alternative.