### PR TITLE
Close #5. Handle more format strings

### DIFF
--- a/poxx.py
+++ b/poxx.py
@@ -21,6 +21,7 @@ import os.path
 import re
 import polib    # from http://bitbucket.org/izi/polib
 from html.parser import HTMLParser
+
 VERSION_STR = '2.0.0'
 
 
@@ -29,6 +30,10 @@ class HtmlAwareMessageMunger(HTMLParser):
     # Lifted from http://translate.sourceforge.net
     ORIGINAL = u"ABCDEFGHIJKLMNOPQRSTUVWXYZ" + u"abcdefghijklmnopqrstuvwxyz"
     REWRITE_UNICODE_MAP = u"ȦƁƇḒḖƑƓĦĪĴĶĿḾȠǾƤɊŘŞŦŬṼẆẊẎẐ" + u"ȧƀƈḓḗƒɠħīĵķŀḿƞǿƥɋřşŧŭṽẇẋẏẑ"
+
+    PLACEHOLDER_REGEX = re.compile(
+        r"((?:%(?:\(\w+\))?[-+]?[\d.]*[sfd])|(?:\{\w+[:]?[\d.]*[sfd]?\}))"
+    )
 
     def __init__(self):
         super().__init__()
@@ -77,7 +82,7 @@ class HtmlAwareMessageMunger(HTMLParser):
     def handle_data(self, data):
         # We don't want to munge placeholders, so split on them, keeping them
         # in the list, then xform every other token.
-        toks = re.split(r"((?:%(?:\(\w+\))?s)|(?:\{\w+\}))", data)
+        toks = self.PLACEHOLDER_REGEX.split(data)
         for i, tok in enumerate(toks):
             if i % 2:
                 self.s += tok

--- a/tests/data/sample.po
+++ b/tests/data/sample.po
@@ -32,3 +32,13 @@ msgstr ""
 #: foo.py:47
 msgid "Three"
 msgstr ""
+
+#: foo.py:47
+msgid ""
+"Zero {name} One {confidence:0.2f} Two Three %(qty)0.2f Four %(name)s Five "
+"%(age)d"
+msgstr ""
+
+#: foo.py:47
+msgid "Zero One {age:3s} Two Three"
+msgstr ""

--- a/tests/test_poxx.py
+++ b/tests/test_poxx.py
@@ -40,7 +40,14 @@ class TestMungePoFile(PoxxTestCase):
         self.assertEqual(munged_pofile[1].msgstr, u'Ǿƞḗ')
         self.assertEqual(munged_pofile[2].msgstr, u'Ŧẇǿ')
         self.assertEqual(munged_pofile[3].msgstr, u'Ŧħřḗḗ')
-
+        self.assertEqual(
+            munged_pofile[4].msgstr,
+            u'Ẑḗřǿ {name} Ǿƞḗ {confidence:0.2f} Ŧẇǿ Ŧħřḗḗ %(qty)0.2f Ƒǿŭř %(name)s Ƒīṽḗ %(age)d',
+        )
+        self.assertEqual(
+            munged_pofile[5].msgstr,
+            u'Ẑḗřǿ Ǿƞḗ {age:3s} Ŧẇǿ Ŧħřḗḗ',
+        )
     def test_blank_munge(self):
         munge_one_file(self.sample_po_path, blank=True)
         munged_pofile = polib.pofile(self.sample_po_path)
@@ -73,7 +80,7 @@ class TestMungePoFile(PoxxTestCase):
         self.assertEqual(munged_pofile[3].msgstr, u'Tree')
 
         untranslated_count = len(munged_pofile.untranslated_entries())
-        self.assertEqual(2, untranslated_count)
+        self.assertEqual(4, untranslated_count)
 
 
 class DiffTestCase(PoxxTestCase):


### PR DESCRIPTION
The regex still doesn't support _all_ possible format strings, but it should get the most common.

I've tried to add support for the `<` and the `>` operators (padding left and right for `{var}` placeholders), but I haven't had much success.